### PR TITLE
Caching + Discord Log View

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
       - name: Cache Container
         id: image-cache
         uses: actions/cache@v3
@@ -34,7 +36,6 @@ jobs:
           key: starbot_container-${{ hashFiles('flake.*') }}
       - name: Build Container
         if: steps.image-cache.outputs.cache-hit != 'true'
-        uses: cachix/install-nix-action@v18
         run: nix build .#image
       - name: SSH Key Creation
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,16 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
+      - name: Cache Container
+        id: image-cache
+        uses: actions/cache@v3
+        with:
+          path: result
+          key: starbot_container-${{ hashFiles('flake.*') }}
+      - name: Build Container
+        if: steps.image-cache.outputs.cache-hit != 'true'
+        uses: cachix/install-nix-action@v18
+        run: nix build .#image
       - name: SSH Key Creation
         run: |
           echo "${{ secrets.ssh-key}}" > .key
@@ -34,7 +44,7 @@ jobs:
           chmod 0600 ./.hosts
       - name: Stop Bot service
         run: ssh -o UserKnownHostsFile=./.hosts -i .key ${{ secrets.username }}@${{ secrets.hostname }} "systemctl --user stop ${{ inputs.service-name }}"
-      - name: Upload Code for Deployment
+      - name: Upload Code and Image for Deployment
         run: rsync -ar --delete -e "ssh -o UserKnownHostsFile=./.hosts -i .key" * ${{ secrets.username }}@${{ secrets.hostname }}:${{ inputs.inst-path }}/
       - name: Start Bot service
         run: ssh -o UserKnownHostsFile=./.hosts -i .key ${{ secrets.username }}@${{ secrets.hostname }} "systemctl --user start ${{ inputs.service-name }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ on:
   
 permissions:
   contents: read
-
+ 
 jobs:  
   deployment:
     runs-on: self-hosted

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
           podman run -v ./:/wd -w /wd docker.io/nixos/nix sh -c 'nix \
             --extra-experimental-features nix-command \
             --extra-experimental-features flakes \
-            build .#image;\
+            build .#${{ inputs.service-name }}
             cp result image
             rm result'
       - name: SSH Key Creation

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build Container
         if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
-          podman run -v ./:/wd -w /wd docker.io/nixos/nix sh -c 'nix \
+          podman run --rm -v ./:/wd -w /wd docker.io/nixos/nix sh -c 'nix \
             --extra-experimental-features nix-command \
             --extra-experimental-features flakes \
             build .#${{ inputs.service-name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,12 @@ jobs:
           key: starbot_container-${{ hashFiles('flake.*') }}
       - name: Build Container
         if: steps.image-cache.outputs.cache-hit != 'true'
-        run: nix build .#image
+        run: |
+          podman run -v ./:/wd -w /wd nixos/nix sh -c 'nix \
+            --extra-experimental-features nix-command \
+            --extra-experimental-features flakes \
+            build .#image;\
+            cp result image'
       - name: SSH Key Creation
         run: |
           echo "${{ secrets.ssh-key}}" > .key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build Container
         if: steps.image-cache.outputs.cache-hit != 'true'
         run: |
-          podman run -v ./:/wd -w /wd nixos/nix sh -c 'nix \
+          podman run -v ./:/wd -w /wd docker.io/nixos/nix sh -c 'nix \
             --extra-experimental-features nix-command \
             --extra-experimental-features flakes \
             build .#image;\

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ on:
   
 permissions:
   contents: read
- 
+
 jobs:  
   deployment:
     runs-on: self-hosted
@@ -39,7 +39,8 @@ jobs:
             --extra-experimental-features nix-command \
             --extra-experimental-features flakes \
             build .#image;\
-            cp result image'
+            cp result image
+            rm result'
       - name: SSH Key Creation
         run: |
           echo "${{ secrets.ssh-key}}" > .key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,13 +26,11 @@ jobs:
     steps:
       - name: Setup repo
         uses: actions/checkout@v3
-      - name: Install Nix
-        uses: cachix/install-nix-action@v18
       - name: Cache Container
         id: image-cache
         uses: actions/cache@v3
         with:
-          path: result
+          path: image
           key: starbot_container-${{ hashFiles('flake.*') }}
       - name: Build Container
         if: steps.image-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pre-deploy-test:
     uses: ./.github/workflows/deno-tests.yml
-  
+
   deploy-dev:
     if: ${{ github.ref == 'refs/heads/dev' }}
     needs: pre-deploy-test
@@ -33,5 +33,3 @@ jobs:
       username: ${{ secrets.DISCORD_USER }}
       hostname: ${{ secrets.DISCORD_HOST }}
       ssh-key: ${{ secrets.DISCORD_USER_SSH_KEY }}
-
-      

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ SECRET
 logs
 db
 *.db
+result

--- a/bot.js
+++ b/bot.js
@@ -1,7 +1,8 @@
-import { createBot, Intents } from "./deps.js";
+import { createBot, Intents,
+	 editBotStatus, PresenceStatus,
+	 ActivityTypes} from "./deps.js";
 import { addBotCommand, enableCommandsPlugin,
-	 updateBotCommands, editBotStatus,
-         PresenceStatus, ActivityTypes } from "./src/lib/commands.js";
+	 updateBotCommands } from "./src/lib/commands.js";
 import { logger } from "./logger.js";
 
 export const bot = createBot({

--- a/bot.js
+++ b/bot.js
@@ -3,7 +3,8 @@ import { addBotCommand, enableCommandsPlugin, updateBotCommands } from "./src/li
 import { logger } from "./logger.js";
 
 export const bot = createBot({
-  intents: Intents.Guilds | Intents.GuildMessages | Intents.MessageContent,
+    intents: Intents.Guilds | Intents.GuildMessages | Intents.MessageContent
+	| Intents.GuildMessageReactions | Intents.GuildWebhooks | Intents.DirectMessages,
   token: Deno.env.get("DISCORD_TOKEN"),
   events: {},
 });

--- a/bot.js
+++ b/bot.js
@@ -1,5 +1,7 @@
 import { createBot, Intents } from "./deps.js";
-import { addBotCommand, enableCommandsPlugin, updateBotCommands } from "./src/lib/commands.js";
+import { addBotCommand, enableCommandsPlugin,
+	 updateBotCommands, editBotStatus,
+         PresenceStatus, ActivityTypes } from "./src/lib/commands.js";
 import { logger } from "./logger.js";
 
 export const bot = createBot({
@@ -18,6 +20,18 @@ addBotCommand(bot, {
     event: "ready",
     actions: [function (bot) {
 	bot.logger.info("Connected to gateway! Bot online!");
+	editBotStatus(bot, {
+	    activities: [
+		{
+		    name: "Doing Something",
+		    type: ActivityTypes.Custom,
+		    created_at: Date.now(),
+		    details: "How long the bot as been running",
+		    state: "Shhh, secrets"
+		}
+	    ],
+	    status: PresenceStatus.online
+	})
 	updateBotCommands(bot);
     }],
 });

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672997035,
-        "narHash": "sha256-DNaNjsGMRYefBTAxFIrVOB2ok477cj1FTpqnu/mKRf4=",
+        "lastModified": 1673606088,
+        "narHash": "sha256-wdYD41UwNwPhTdMaG0AIe7fE1bAdyHe6bB4HLUqUvck=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f1ffcf798e93b169321106a4aef79526a2b4bd0a",
+        "rev": "37b97ae3dd714de9a17923d004a2c5b5543dfa6d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,15 +27,10 @@
           deno run -A main.js
         '';
       };
-    in {
-      apps.default = {
-        type = "app";
-        program = "${starBot}/bin/starbot";
-      };
-      packages.default = starBot;
-      packages.image = pkgs.dockerTools.buildImage {
+
+      mkImage = (tag: pkgs.dockerTools.buildImage {
         name = "starbot";
-        tag = "latest";
+        tag = "${tag}";
         copyToRoot = pkgs.buildEnv {
           name = "starbot-root";
           paths = [ starBot pkgs.bashInteractive ];
@@ -43,7 +38,18 @@
             "/bin"
           ];
         };
+      });
+      
+    in {
+      apps.default = {
+        type = "app";
+        program = "${starBot}/bin/starbot";
       };
+      
+      packages.StarBot = mkImage "latest";
+
+      packages.StarBot-Test = mkImage "dev";
+      
       devShells.default = pkgs.mkShell {
         nativeBuildInputs = [ pkgs.bashInteractive ];
         buildInputs = deps;

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
         type = "app";
         program = "${starBot}/bin/starbot";
       };
+      packages.default = starBot;
       packages.image = pkgs.dockerTools.buildImage {
         name = "starbot";
         tag = "latest";

--- a/src/commands/bqn.js
+++ b/src/commands/bqn.js
@@ -5,12 +5,13 @@ import {
     sendMessage
 } from "../../deps.js";
 
+// Debated making a function for extracting code
+// But, I want to also add an options query
+// or args format to pass on
+const codeRegex = /(?:```bqn\n)([\s\S]*\n?)(?:```)/;
+
 function diagram(bot, msg) {
     const cont = msg.content;
-    // Debated making a function for extracting code
-    // But, I want to also add an options query
-    // or args format to pass on
-    const codeRegex = /(?:```bqn\n)([\s\S]*\n?)(?:```)/;
 
     let code = cont.match(codeRegex);
     
@@ -31,6 +32,9 @@ function diagram(bot, msg) {
 addBotCommand(bot, {
     type: "content",
     name: "Run BQN Code",
+    runIf: (_bot, msg) => {
+	return (msg.content.match(codeRegex)) != null
+    },
     actions: [
 	diagram,
     ],

--- a/src/commands/d2.js
+++ b/src/commands/d2.js
@@ -5,12 +5,13 @@ import {
     sendMessage
 } from "../../deps.js";
 
+const codeRegex = /(?:```d2\n)([\s\S]*\n?)(?:```)/;
+
 function diagram(bot, msg) {
     const cont = msg.content;
     //                          [Match everything]
     //                [Don't match]|       [Don't match]
     //                 v           v           v
-    const codeRegex = /(?:```d2\n)([\s\S]*\n?)(?:```)/;
     const code = cont.match(codeRegex);
     if (code != null) {
 	const url = `https://starbot.syzygial.cc/d2?code=${encode(code[1])}`;
@@ -24,6 +25,9 @@ function diagram(bot, msg) {
 addBotCommand(bot, {
     type: "content",
     name: "Create D2 diagram",
+    runIf: (_bot, msg) => {
+	return (msg.content.match(codeRegex)) != null
+    },
     actions: [
 	diagram,
     ],

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -38,8 +38,6 @@ function makeComponents(page) {
 
 function logGet(bot, interaction) {
     let page = 1;
-    console.log(interaction);
-    console.log(interaction.data);
     if (interaction.data.customId) {
 	const action = interaction.data.customId;
 	page = parseInt(action.charAt(action.length-1));

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -58,8 +58,8 @@ function logGet(bot, interaction) {
     let msg = '';
     for (const row of rows) {
 	let date = new Date(row[1]);
-	date = `${date.getFullYear()} ${date.getMonth()+1} ${date.getDate()} ${date.getHours()}:${date.getMinutes()}`;
-	msg += `\u001b[3${Math.floor(row[0]/10)}m${date} ${row[2].slice(0,50)}\n`;
+	date = `${date.getFullYear()}/${date.getMonth()+1}/${date.getDate()} ${date.getHours()}:${date.getMinutes()}`;
+	msg += `\u001b[3${Math.floor(row[0]/10)}m${date} ${row[2].slice(0,100)}\n\n`;
     }
     
     editOriginalInteractionResponse(bot, interaction.token, {

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -63,12 +63,16 @@ function logGet(bot, interaction) {
     }
     
     editOriginalInteractionResponse(bot, interaction.token, {
-	content: `Log Preview
-\`\`\`ansi
-${msg}
-\`\`\`
-`,
 	customId: `${page}`,
+	embeds: [
+	    {
+		title: "Log Preview",
+		type: "rich",
+		description: `\`\`\`ansi
+${msg}
+\`\`\``		
+	    }
+	],
 	components: makeComponents(page)
     });
 }

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -40,7 +40,7 @@ function logGet(bot, interaction) {
     let page = 1;
     if (interaction.data.customId) {
 	const action = interaction.data.customId;
-	page = parseInt(action.charAt(action.length-1));
+	page = parseInt(action.match(/[\d]+/));
 	if (action.startsWith("log_prev"))
 	    page -=1;
 	else if (action.startsWith("log_next"))
@@ -77,6 +77,7 @@ addBotCommand(bot, {
     type: "slash",
     name: "log",
     description: "Get some logs",
+    noLog: true,
     actions: [
 	logGet,
     ],

--- a/src/commands/roll.js
+++ b/src/commands/roll.js
@@ -20,6 +20,9 @@ function rolling(bot, msg) {
 addBotCommand(bot, {
     type: "content",
     name: "Convert message to rolls",
+    runIf: (_bot, msg) => {
+	return (msg.content.match(/\{([^}]+)}/)) != null
+    },
     actions: [
 	rolling,
     ],

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -1,7 +1,8 @@
 import { Events } from "./commandEvents.js";
 import {
     ApplicationCommandTypes,
-    InteractionTypes,
+    // InteractionTypes, TODO: Use InteractionTypes to index actions
+    // for easier component response organization
     upsertGlobalApplicationCommands,
 } from "../../deps.js";
 

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -37,13 +37,7 @@ export function enableCommandsPlugin(bot) {
 }
 
 function filterApplicationCommand(_bot, interaction) {
-    if (interaction.type == InteractionTypes.ApplicationCommand) {
-	console.log(interaction)
-	if (interaction.data.name == this.name) {
-	    return true;
-	}
-    }
-    return false;
+    return interaction.data.name == this.name;
 }
 
 const builtinCommandTypes = {

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -38,8 +38,8 @@ export function enableCommandsPlugin(bot) {
 }
 
 function filterApplicationCommand(_bot, interaction) {
-    console.log(interaction)
-    return interaction.data.name == this.name;
+    return interaction.data.name == this.name ||
+	interaction.data.customId.startsWith(this.name); 
 }
 
 const builtinCommandTypes = {

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -38,8 +38,8 @@ export function enableCommandsPlugin(bot) {
 }
 
 function filterApplicationCommand(_bot, interaction) {
-    return interaction.data.name == this.name ||
-	interaction.data.customId.startsWith(this.name); 
+    return interaction.data?.name == this.name ||
+	interaction.data?.customId.startsWith(this.name); 
 }
 
 const builtinCommandTypes = {

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -29,7 +29,7 @@ export function enableCommandsPlugin(bot) {
 		    }
 		} else {
 		    /* Will soon be replaced by proper logging */
-		    logger.error("Should be unreachable");
+		    bot.logger.error("Should be unreachable");
 		}
 	    }
 	};

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -93,16 +93,6 @@ export function addBotCommand(bot, command) {
     // Command format validated, generate UUID for command
     com.uuid = crypto.randomUUID();
     bot.commands.push(com);
-    if (com.type == ApplicationCommandTypes.ChatInput || com.type == ApplicationCommandTypes.Message) {
-	// For Modals and Buttons etc.
-	const webHook = {
-	    event: "webhooksUpdate",
-	    name: com.name,
-	    type: "Create Webhook for Interactions",
-	    actions: com.actions
-	}
-	bot.commands.push(webHook);
-    }
     bot.logger.debug(`Added command to bot: ${JSON.stringify(command)}`,"botCommandPlugin",command.name)
     return com;
 }

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -23,7 +23,8 @@ export function enableCommandsPlugin(bot) {
 		    ) {
 			for (const action of command.actions) {
 			    if (typeof (action) == "function") {
-				bot.logger.debug(`Running command ${command.name}`,"botCommandPlugin");
+				if (!command.noLog)
+				    bot.logger.debug(`Running command ${command.name}`,"botCommandPlugin");
 				action(...args);
 			    }
 			}

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -38,8 +38,8 @@ export function enableCommandsPlugin(bot) {
 }
 
 function filterApplicationCommand(_bot, interaction) {
-    return interaction.data?.name == this.name ||
-	interaction.data?.customId.startsWith(this.name); 
+    return interaction.data.name == this.name ||
+	interaction.data.customId?.startsWith(this.name); 
 }
 
 const builtinCommandTypes = {

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -38,6 +38,7 @@ export function enableCommandsPlugin(bot) {
 }
 
 function filterApplicationCommand(_bot, interaction) {
+    console.log(interaction)
     return interaction.data.name == this.name;
 }
 


### PR DESCRIPTION
Currently interactions rely on the customId of the components start with the name of the interaction. This is because component interactions are technically separate from the initial interaction, and when fed back to the bot have no indicators of what interaction they came from.

Maybe making a `addBotCommand` type for buttons and the like would be good, who knows.