### PR TITLE
Discord Python Commands

### DIFF
--- a/.github/workflows/deno-tests.yml
+++ b/.github/workflows/deno-tests.yml
@@ -54,4 +54,4 @@ jobs:
           podman run --rm -v ./:/wd:Z -w /wd starbot:$tag lints
       - name: Run tests
         run: |
-          podman run --rm -v ./:/wd:Z -w /wd starbot:$tag tests
+          podman run --rm --security-opt label=type:container_userns_t --security-opt label=type:spc_t --device /dev/fuse --cap-add sys_admin --mount type=tmpfs,destination=/tmp -v ./:/wd:Z -w /wd starbot:$tag tests

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ logs
 db
 *.db
 result
+./data/training
+/data/training/

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -15,13 +18,52 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flatTmpFuse": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1690760774,
+        "narHash": "sha256-sgib7pZLmkIGIyAybrPNAXNID7XbJC+Pd/u9RI4jrz0=",
+        "owner": "CyborgPotato",
+        "repo": "FuseFlatTmpfs",
+        "rev": "047ccfe0cadfd8bd17a74174aff22c65038fda44",
+        "type": "github"
+      },
+      "original": {
+        "owner": "CyborgPotato",
+        "repo": "FuseFlatTmpfs",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673606088,
-        "narHash": "sha256-wdYD41UwNwPhTdMaG0AIe7fE1bAdyHe6bB4HLUqUvck=",
+        "lastModified": 1689449371,
+        "narHash": "sha256-sK3Oi8uEFrFPL83wKPV6w0+96NrmwqIpw9YFffMifVg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "37b97ae3dd714de9a17923d004a2c5b5543dfa6d",
+        "rev": "29bcead8405cfe4c00085843eb372cc43837bb9d",
         "type": "github"
       },
       "original": {
@@ -34,7 +76,38 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "flatTmpFuse": "flatTmpFuse",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,22 @@
   description = "Denocord Discord Bot";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.flatTmpFuse.url = "github:CyborgPotato/FuseFlatTmpfs";
+  inputs.flatTmpFuse.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, flatTmpFuse }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
-      
+      tmpfsFlat = flatTmpFuse.packages.${system}.default;
+      py = pkgs.python3;
+
+      pyenv = py.withPackages (p: with p; [
+        matplotlib
+        numpy
+        scipy
+        pillow
+      ]);      
+
       deps = with pkgs; [
         deno
         # Graphs
@@ -18,7 +29,14 @@
         # Funny WingDing Language
         cbqn
         # Python
-        pypy3
+        pyenv
+        # Sandboxing tool, for safety executing... well, Arbitrary code.
+        bubblewrap
+        # Directory Userspace TMPFS w/ limits
+        tmpfsFlat
+        fuse3
+        # timeout
+        coreutils
         # Chess
         gnuchess
       ];
@@ -81,7 +99,9 @@
       
       devShells.default = pkgs.mkShell {
         nativeBuildInputs = [ pkgs.bashInteractive ];
-        buildInputs = deps;
+        buildInputs = deps ++ (with pkgs; [
+          sqlite          
+        ]);
       };
     });
 }

--- a/logger.js
+++ b/logger.js
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS logTags(
 		     log.level,
 		     log.msg,
 		 ],
-		);
+	);
 	const logId = db.lastInsertRowId;
 	for (const tag of log.tags) {
 	    db.query('INSERT INTO logTags (logId, tag) VALUES (?,?);',[logId, tag]);

--- a/main.js
+++ b/main.js
@@ -1,3 +1,5 @@
+// Tired of having BigInts not serialize.
+BigInt.prototype.toJSON = function() { return this.toString() }
 // This file responsible for coordinating all other files and actually starting the bot
 import { startBot, walkSync } from "./deps.js";
 import { startWeb } from "./src/web/srv.js";

--- a/src/commands/log.js
+++ b/src/commands/log.js
@@ -67,9 +67,9 @@ function logGet(bot, interaction) {
 	    page -=1;
 	else if (action.startsWith("log_next"))
 	    page +=1;
-	ackInteraction(interaction, "deferred");
+	ackInteraction(interaction, "deferred", {ephemeral: true});
     }else {
-	ackInteraction(interaction, "thinking");
+	ackInteraction(interaction, "thinking", {ephemeral: true});
 	id = options?.filter(
 	    (option) => option.name == "id"
 	)[0]?.value;

--- a/src/commands/userprog/basecommand.js
+++ b/src/commands/userprog/basecommand.js
@@ -1,0 +1,111 @@
+import {
+    ApplicationCommandOptionTypes,
+} from "../../../deps.js";
+import { bot } from "../../../bot.js";
+import { addBotCommand } from "../../lib/commands.js";
+
+import { } from "../../lib/usercomms/commandDB.js";
+
+import { masterAction, masterRunAction } from "../../lib/usercomms/masterAction.js";
+
+const maxCommandName = 30;
+
+addBotCommand(bot, {
+    description: "Run and Make Custom Programs and Games!",
+    name: "usergame",
+    options: [{
+	name: "create",
+	description: "Create a new command",
+	type: ApplicationCommandOptionTypes.SubCommand,
+	options: [
+	    {
+		name: "command",	    
+		type: ApplicationCommandOptionTypes.String,
+		description: "The name of the command you're making",
+		required: true,
+		max_length: maxCommandName
+	    },
+	]
+    }, {
+	name: "update",
+	description: "Update an existing command *you* made",
+	type: ApplicationCommandOptionTypes.SubCommand,
+	options: [
+	    {
+		name: "command",	    
+		type: ApplicationCommandOptionTypes.String,
+		description: "The name of the command you're updating",
+		required: true,
+		max_length: maxCommandName
+	    },
+	]
+    }, {
+	name: "run",
+	description: "Run an existing command",
+	type: ApplicationCommandOptionTypes.SubCommand,
+	options: [
+	    {
+		name: "command",	    
+		type: ApplicationCommandOptionTypes.String,
+		description: "The name of the command you want to run",
+		required: true,
+		max_length: maxCommandName
+	    }, {
+		name: "input",
+		type: ApplicationCommandOptionTypes.String,
+		description: "Input text for the command",
+		required: false,
+	    }, {
+		name: "hidden",
+		type: ApplicationCommandOptionTypes.Boolean,
+		description: "Should only you see this?",
+		required: false,
+	    },
+	]
+    }, {
+	name: "delete",
+	description: "Delete an existing command *you* made",
+	type: ApplicationCommandOptionTypes.SubCommand,
+	options: [
+	    {
+		name: "command",	    
+		type: ApplicationCommandOptionTypes.String,
+		description: "The name of the command you're deleting",
+		required: true,
+		max_length: maxCommandName
+	    },
+	]
+    }, {
+	name: "info",
+	description: "Get info about a command",
+	type: ApplicationCommandOptionTypes.SubCommand,
+	options: [
+	    {
+		name: "command",	    
+		type: ApplicationCommandOptionTypes.String,
+		description: "The name of the command you want info on",
+		required: true,
+		max_length: maxCommandName
+	    },
+	]
+    }, {
+	name: "list",
+	description: "List all commands!",
+	type: ApplicationCommandOptionTypes.SubCommand,
+	options: [
+	]
+    }],
+    type: "slash",
+    actions: [
+	masterAction
+    ]
+});
+
+addBotCommand(bot, {
+    description: "Run a User Command on a Message",
+    name: "userrun",
+    type: "message",
+    actions: [
+	masterRunAction
+    ]
+});

--- a/src/lib/bqn.js
+++ b/src/lib/bqn.js
@@ -4,25 +4,26 @@ export async function runBQN(code) {
     const enc = new TextEncoder();
     const dec = new TextDecoder();
 
-    const bqn = Deno.run({
-	cmd: ["cbqn"],
+    const bqnCommand = new Deno.Command("cbqn", {
 	stderr: "piped",
 	stdout: "piped",
 	stdin: "piped"
     });
+    const bqn = bqnCommand.spawn();
 
     logger.info(`Received code: ${code}`,"libBQN");
-    
+
+    const bqnin = await bqn.stdin.getWriter();
     const bytes = enc.encode(code);
     let i = 0;
     let n = 0;
     do {
-	n = await bqn.stdin.write(bytes.slice(i));
+	n = await bqnin.write(bytes.slice(i));
 	i += n;
     } while(n)
-    await bqn.stdin.close();
-    const output = await bqn.output();
-    await bqn.close();
+	await bqnin.close();
+    const bqnout = await bqn.output();
+    const output = bqnout.stdout;
 
     return dec.decode(output).trimEnd();
 }

--- a/src/lib/bqn_test.js
+++ b/src/lib/bqn_test.js
@@ -1,0 +1,9 @@
+import { assert } from "../../deps.js";
+import { runBQN } from "./bqn.js";
+
+Deno.test("BQN Test", async (t) => {
+    await t.step("BQN Test Expression", async () => {
+	const res = await runBQN("1+2");
+	assert("   3" == res);
+    });
+});

--- a/src/lib/chess/chess_test.js
+++ b/src/lib/chess/chess_test.js
@@ -8,7 +8,7 @@ Deno.test("Chess Testing", async (t) => {
 	await chess.make(n);
 	await chess.play(n,"a4");
 	await chess.play(n,"h6");
-	const board = (await chess.board(n));
+	const board = await chess.board(n);
 	await chess.close(n);
 	const expect = await Deno.readTextFile("./src/lib/chess/expectedboard.txt");
 	console.log(board);
@@ -35,7 +35,6 @@ Deno.test("Chess Testing", async (t) => {
 	const n = "State";
 	await chess.make(n);
 	const res = await chess.state(n);
-	console.log(res);
 	await chess.close(n);
 	assert(res.length == 4936);
     });

--- a/src/lib/usercomms/commandDB.js
+++ b/src/lib/usercomms/commandDB.js
@@ -1,0 +1,225 @@
+import { db } from "../../../sql.js";
+import { } from "../../../deps.js";
+
+const max_attachment_size = 25 * 1024*1024;
+
+class CommandDB {
+    constructor() {
+	db.execute(`
+CREATE TABLE IF NOT EXISTS commandDB(
+    _id INTEGER PRIMARY KEY ASC AUTOINCREMENT,
+    owner TEXT NOT NULL,
+    name TEXT UNIQUE NOT NULL,
+    created TEXT NOT NULL,
+    modified TEXT,
+    invoked INTEGER DEFAULT 0,
+    code TEXT NOT NULL
+);
+	`);
+	/* TODO:
+
+	   Implement other tables such as for variable storage and
+	   acess so that command variables can persist for longer than
+	   the life of the executed user program */
+    }
+
+    createCommand(owner, name, code) {
+	const now = Date.now()
+	try {
+	    db.query('INSERT INTO commandDB(owner, name, created, code) VALUES (?, ?, ?, ?);',
+		     [
+			 owner,
+			 name,
+			 now,
+			 code,
+		     ],
+	    );
+	} catch (error) {
+	    // TODO: Use Logger
+	    console.error(`Error: ${error}`);
+	    return false;
+	}
+	return true;
+    }
+
+    searchCommand(query) {
+	let owner, name;
+	if (query) {
+	    ({owner, name} = query);
+	}
+	let res;
+	if (owner && name) {
+	    res = db.query('SELECT * FROM commandDB WHERE owner = (?) AND name = (?);',
+			   [
+			       owner,
+			       name
+			   ]
+	    );
+	}else if (owner) {
+	    res = db.query('SELECT * FROM commandDB WHERE owner = (?);',
+			   [
+			       owner
+			   ]
+	    );
+	}else if (name) {
+	    res = db.query('SELECT * FROM commandDB WHERE name = (?);',
+			   [
+			       name
+			   ]
+	    );
+	}else {
+	    res = db.query('SELECT * FROM commandDB;');
+	}
+	return res;
+    }
+    
+    updateCommand(owner, name, code) {
+	const res = this.searchCommand({owner, name});
+	if (res.length == 1) {
+	    const now = Date.now();
+	    db.query('UPDATE commandDB SET (modified, code) = (?, ?) WHERE owner = (?) AND name = (?);'
+		    ,[
+			now,
+			code,
+			owner,
+			name,
+		    ],
+	    );
+	    return true;
+	}
+	console.error("No command exists to update")
+	return false;
+    }
+
+    async runCommand(name, textInput) {
+	const enc = new TextEncoder();
+	const command = this.searchCommand({name})[0];
+	const code = command[command.length-1];
+	const tmpCodeDir = await Deno.makeTempDir();
+
+	Deno.writeTextFileSync(`${tmpCodeDir}/main.py`, code);
+	Deno.mkdirSync(`${tmpCodeDir}/out`);
+
+	const tmpfsCommand = new Deno.Command("FlatTMPFUSE", {
+	    args: [
+		`--size=${max_attachment_size}`,
+		"--max-inodes=10",
+		`--max-filesize=${max_attachment_size*2}`,
+		`${tmpCodeDir}/out`
+	    ]
+	});
+
+	tmpfsCommand.outputSync()
+	
+	const utmpfsCommand = new Deno.Command("fusermount3", {
+	    args: [
+		"-u",
+		`${tmpCodeDir}/out`
+	    ]
+	});
+
+	// TODO: Build with Nix so Paths are *clean*
+	const timeoutPythonCommand = new Deno.Command("timeout", {
+	    args: [
+		"30s",
+		"bwrap",
+		"--unshare-all",
+		"--clearenv",
+		"--setenv",
+		"PATH",
+		Deno.env.get("PATH"),
+		"--ro-bind",
+		`${tmpCodeDir}`,
+		"/app",
+		"--ro-bind",
+		"/nix",
+		"/nix",
+		"--bind",
+		`${tmpCodeDir}/out`,
+		"/out",
+		"--remount-ro",
+		"/",
+		"python3",
+		"-Iq",
+		"/app/main.py"
+	    ],
+	    stdin: "piped",
+	    stdout: "piped",
+	    stderr: "piped",
+	});
+
+	const py = await timeoutPythonCommand.spawn();
+	const pyin = await py.stdin.getWriter();
+
+	if (textInput) {
+	    const bytes = enc.encode(textInput);
+	    let i = 0;
+	    let n = 0;
+	    do {
+		n = await pyin.write(bytes.slice(i));
+		i += n;
+	    } while(n)
+	}
+	await pyin.close();
+
+	const pyout = await py.output();
+
+	const files = [];
+	
+	/* Collect Output Files*/
+	for (const outFile of Deno.readDirSync(`${tmpCodeDir}/out`)) {
+	    files.push({
+		name: outFile.name,
+		blob: new Blob([Deno.readFileSync(`${tmpCodeDir}/out/${outFile.name}`)])
+	    });
+	}
+	/* Clear Tmpfs */
+	utmpfsCommand.outputSync();
+	
+	await Deno.remove(tmpCodeDir, {recursive: true});
+
+	return formatOutput(pyout, files);
+    }
+    
+    deleteCommand(owner, name) {
+	db.query('DELETE FROM commandDB WHERE owner = (?) AND name = (?);',[
+	    owner,
+	    name
+	])
+    }
+    
+    queryCommandName(name) {
+	const resp = db.query("SELECT owner,created FROM commandDB WHERE name = (name);", [name])
+	return resp.length > 0;
+    }
+}
+
+export const usergameDB = new CommandDB();
+
+// Command Output (Discord Formatting)
+
+const dec = new TextDecoder();
+
+function formatOutput(commandOut, files) {
+    const { _code, stdout, _stderr } = commandOut;
+    let content = "";
+
+    // TODO: More Format Options, like attachments and rich etc.
+
+    content = dec.decode(stdout);
+
+    // preTrim Content For Discord
+    content = content.trimEnd();
+
+    if (content.length == 0) {
+	content = "Command Dun Did Run";
+    }
+
+    // Ensure message isn't too long to send
+    content = content.slice(0,2000)
+    
+    return {
+	content,
+	file: files.length == 0 ? undefined: files
+    }
+}

--- a/src/lib/usercomms/createCommand.js
+++ b/src/lib/usercomms/createCommand.js
@@ -1,0 +1,61 @@
+import ackInteraction from "../../util/ackInteraction.js";
+import {
+    MessageComponentTypes,
+    TextStyles,
+} from "../../../deps.js";
+import { usergameDB } from "./commandDB.js";
+
+export function createCommand(bot, interaction) {
+    const createOptions = interaction.data.options.filter(
+	o => o.name == "create"
+    )[0].options;
+
+    const commandId = createOptions.filter(
+	o => o.name == "command"
+    )[0]["value"];
+
+    bot.logger.debug(`Creating command for ${commandId}`);
+
+    // Check if command name exists, if it does, complain
+    // Otherwise present the modal
+
+    const exists = usergameDB.searchCommand({name: commandId})
+
+    if (exists.length != 0) {
+	ackInteraction(
+	    interaction,
+	    "message",
+	    {ephemeral: true},
+	    {
+		content: `Command with name ${commandId} already exists`
+	    }
+	);
+    }else {
+	let userId;
+	if (interaction.member) {
+	    userId = `${interaction.member.id}`;
+	}else {
+	    userId = `${interaction.user.id}`;
+	}
+
+	ackInteraction(
+	    interaction,
+	    "modal",
+	    {ephemeral: true},
+	    {
+		// TODO: Actually get ID
+		customId: `usergame_${userId}_src_create`,
+		title: `${commandId}: Code Creation`,
+		components: [{
+		    type: MessageComponentTypes.ActionRow,
+		    components: [{
+			type: MessageComponentTypes.InputText,
+			customId: `${commandId}`,
+			style: TextStyles.Paragraph,
+			label: "Source Code"
+		    }]	
+		}]
+	    }
+	);
+    }
+}

--- a/src/lib/usercomms/deleteCommand.js
+++ b/src/lib/usercomms/deleteCommand.js
@@ -1,0 +1,60 @@
+import ackInteraction from "../../util/ackInteraction.js";
+import {
+} from "../../../deps.js";
+import { usergameDB } from "./commandDB.js";
+
+export function deleteCommand(bot, interaction) {
+    const createOptions = interaction.data.options.filter(
+	o => o.name == "delete"
+    )[0].options;
+
+    const commandId = createOptions.filter(
+	o => o.name == "command"
+    )[0]["value"];
+
+    bot.logger.debug(`Deleting command ${commandId}`);
+
+    const exists = usergameDB.searchCommand({name: commandId})
+
+    if (exists.length == 0) {
+	ackInteraction(
+	    interaction,
+	    "message",
+	    {ephemeral: true},
+	    {
+		content: `Command with name ${commandId} does not exist!`
+	    }
+	);
+    }else {
+	const commandUserId = exists[0][1];
+	let userId;
+	if (interaction.member) {
+	    userId = `${interaction.member.id}`;
+	}else {
+	    userId = `${interaction.user.id}`;
+	}
+	if (userId == commandUserId) {
+	    usergameDB.deleteCommand(userId, commandId);
+	    ackInteraction(
+		interaction,
+		"message",
+		{ephemeral: true},
+		{
+		    content: `Deleted ${commandId}`
+		}
+	    );
+	}else {
+	    bot.logger.debug(`User ${userId} tried to modify ${commandUserId}'s command`);
+
+	    ackInteraction(
+		interaction,
+		"message",
+		{ephemeral: true},
+		{
+		    content: `You did not make ${commandId}`
+		}
+	    );
+	}
+    }
+    return
+}

--- a/src/lib/usercomms/infoCommand.js
+++ b/src/lib/usercomms/infoCommand.js
@@ -1,0 +1,56 @@
+import ackInteraction from "../../util/ackInteraction.js";
+import {} from "../../../deps.js";
+import { usergameDB } from "./commandDB.js";
+
+export function infoCommand(bot, interaction) {
+    const createOptions = interaction.data.options.filter(
+	o => o.name == "info"
+    )[0].options;
+    
+    const commandId = createOptions.filter(
+	o => o.name == "command"
+    )[0]["value"];
+    
+    bot.logger.debug(`Running command ${commandId}`);
+
+    const exists = usergameDB.searchCommand({name: commandId})
+
+    if (exists.length == 0) {
+	ackInteraction(
+	    interaction,
+	    "message",
+	    {ephemeral: true},
+	    {
+		content: `Command with name ${commandId} does not exist!`
+	    }
+	);
+    }else {
+	const commandData = exists[0];
+	const creatorId = commandData[1];
+	const commandName = commandData[2];
+	const source = commandData[6];
+	const created = commandData[3].slice(0,-3);
+	let modified = commandData[4];
+	if (modified == null) {
+	    modified = "";
+	}else {
+	    modified = `, last modified <t:${modified.slice(0,-3)}>`;
+	}
+
+	ackInteraction(
+	    interaction,
+	    "message",
+	    {}, {
+		embeds: [{
+		    title: `"${commandName}" Command`,
+		    color: 0x9400d3,
+		    description: `Made By: <@${creatorId}>
+\`\`\`python
+${source.slice(0,3900)}\`\`\`
+Command created <t:${created}>${modified}`,
+		}]
+	    }
+	);
+    }
+    return
+}

--- a/src/lib/usercomms/listCommand.js
+++ b/src/lib/usercomms/listCommand.js
@@ -1,0 +1,80 @@
+import ackInteraction from "../../util/ackInteraction.js";
+import { usergameDB } from "./commandDB.js";
+import {
+    editOriginalInteractionResponse,
+} from "../../../deps.js";
+
+function makeComponents(page) {
+    return [
+	{
+	    type: 1,
+	    components: [
+		{
+		    type: 2,
+		    label: "Prev",
+		    style: 1,
+		    customId: `prg_prev${page}`,
+		    disabled: page==1
+		},
+		{
+		    type: 2,
+		    label: `${page}`,
+		    style: 2,
+		    customId: "prg_page",
+		    disabled: true
+		},
+		{
+		    type: 2,
+		    label: "Next",
+		    style: 1,
+		    customId: `prg_next${page}`
+		}
+	    ]
+	}
+    ]
+}
+
+function prgList(page) {
+    const fields = [];
+    const commands = usergameDB.searchCommand();
+    for (const command of commands.slice((page-1)*10,page*10)) {
+	fields.push({
+	    name: command[2],
+	    value: `Made by: <@${command[1]}>`
+	});
+    }
+    if (fields.length == 0)
+	return undefined;
+    return fields;
+}
+
+export function listCommand(bot, interaction) {
+    let page = 1;
+
+    if (interaction.data.customId) {
+	const action = interaction.data.customId;
+	page = parseInt(action.match(/[\d]+/));
+	if (action.startsWith("prg_prev"))
+	    page -=1;
+	else if (action.startsWith("prg_next"))
+	    page +=1;
+	ackInteraction(interaction, "deferred", {ephemeral: true});
+    }else {
+	ackInteraction(interaction, "thinking", {ephemeral: true});
+    }
+
+    const fields = prgList(page);
+
+    bot.logger.debug(`${JSON.stringify(fields)}`);
+    
+    editOriginalInteractionResponse(bot, interaction.token, {
+	customId: `${page}`,
+	embeds: [
+	    {
+		title: "Log Preview",
+		fields: fields
+	    }
+	],
+	components: makeComponents(page)
+    });
+}

--- a/src/lib/usercomms/masterAction.js
+++ b/src/lib/usercomms/masterAction.js
@@ -1,0 +1,113 @@
+import {
+    InteractionTypes,
+    MessageComponentTypes,
+    TextStyles,
+} from "../../../deps.js";
+import ackInteraction from "../../util/ackInteraction.js";
+
+import { createCommand } from "../../lib/usercomms/createCommand.js";
+import { updateCommand } from "../../lib/usercomms/updateCommand.js";
+import { sourceCommand } from "../../lib/usercomms/sourceSubmit.js";
+import { runCommand } from "../../lib/usercomms/runCommand.js";
+import { deleteCommand } from "../../lib/usercomms/deleteCommand.js";
+import { infoCommand } from "../../lib/usercomms/infoCommand.js";
+import { listCommand } from "../../lib/usercomms/listCommand.js";
+
+const subcommands = {
+    "create": createCommand,
+    "update": updateCommand,
+    "src": sourceCommand,
+    "run": runCommand,
+    "delete": deleteCommand,
+    "info": infoCommand,
+    "list": listCommand,
+};
+
+export function masterAction(bot, interaction) {
+    const data = interaction.data;
+    bot.logger.debug(`Received and running UserComm`)
+
+    switch(interaction.type) {
+	case InteractionTypes.ModalSubmit:
+	case InteractionTypes.MessageComponent: {
+	    if (!data.customId.includes("usergame"))
+		return;
+	    const commInstr = data.customId.split('_');
+	    const action = commInstr[2];
+	    if (action in subcommands) {
+		subcommands[action](bot, interaction)
+		return;
+	    }
+	    /* TODO:
+	       Decide format for custom modals run by user code
+	     */
+	    break;
+	}
+	case InteractionTypes.ApplicationCommand: {
+	    if (!data.options)
+		return;
+	    for (const option of data.options) {
+		if (option.name in subcommands) {
+		    subcommands[option.name](bot, interaction);
+		    break;
+		}
+	    }
+	    break;
+	} default: {
+	    return;
+	}
+    }
+}
+
+export function masterRunAction(bot, interaction) {
+    const data = interaction.data;
+    switch(interaction.type) {
+	case InteractionTypes.ModalSubmit:
+	case InteractionTypes.MessageComponent: {
+	    if (!data.customId.includes("userrun"))
+		return;
+	    const commInstr = data.customId.split('_');
+	    const action = commInstr[1];
+	    if (action in subcommands) {
+		subcommands[action](bot, interaction)
+		return;
+	    }
+	    break;
+	}
+	case InteractionTypes.ApplicationCommand: {
+	    const msgText = interaction.data.resolved.messages.values().next().value.content;
+	    ackInteraction(
+		interaction,
+		"modal",
+		{},
+		{
+		    customId: `userrun_run`,
+		    title: `Run a Command`,
+		    components: [
+			{
+			    type: MessageComponentTypes.ActionRow,
+			    components: [{
+				type: MessageComponentTypes.InputText,
+				customId: `command`,
+				style: TextStyles.Short,
+				label: "Command Name"
+			    }]
+			}, {
+			    type: MessageComponentTypes.ActionRow,
+			    components: [{
+				type: MessageComponentTypes.InputText,
+				customId: `input`,
+				style: TextStyles.Paragraph,
+				label: "Command Name",
+				value: msgText
+			    }]
+			}
+		    ]
+		}
+	    );
+	    break;
+	} default: {
+	    return;
+	}
+    }    
+}

--- a/src/lib/usercomms/runCommand.js
+++ b/src/lib/usercomms/runCommand.js
@@ -1,0 +1,74 @@
+import ackInteraction from "../../util/ackInteraction.js";
+import {
+    InteractionTypes,
+} from "../../../deps.js";
+import { usergameDB } from "./commandDB.js";
+
+export async function runCommand(bot, interaction) {
+    const sourceData = interaction.data;
+
+    let input;
+    let hidden = false;
+    let commandId;
+
+    switch(interaction.type) {
+	case InteractionTypes.ModalSubmit: {
+	    const commandComponent = sourceData.components[0].components[0];
+	    commandId = commandComponent.value;
+	    const inputComponent = sourceData.components[1].components[0];
+	    input = inputComponent.value;
+	    break;
+	}
+	case InteractionTypes.ApplicationCommand: {
+	    const createOptions = interaction.data.options.filter(
+		o => o.name == "run"
+	    )[0].options;
+
+	    commandId = createOptions.filter(
+		o => o.name == "command"
+	    )[0]["value"];
+
+	    const inputMaybe = createOptions.filter(
+		o => o.name == "input"
+	    );
+
+	    if (inputMaybe.length == 1) {
+		input = inputMaybe[0]["value"];
+	    }
+
+	    const hiddenMaybe = createOptions.filter(
+		o => o.name == "hidden"
+	    );
+
+	    if (hiddenMaybe.length == 1) {
+		hidden = hiddenMaybe[0]["value"];
+	    }
+	}
+    }
+
+    bot.logger.debug(`Running command ${commandId}`);
+
+    const exists = usergameDB.searchCommand({name: commandId})
+
+    if (exists.length == 0) {
+	ackInteraction(
+	    interaction,
+	    "message",
+	    {ephemeral: true},
+	    {
+		content: `Command with name ${commandId} does not exist!`
+	    }
+	);
+    }else {
+	ackInteraction(
+	    interaction,
+	    "thinking",
+	    {ephemeral: hidden}
+	);
+	const output = await usergameDB.runCommand(commandId, input);
+	bot.logger.debug(`Command output:\n ${JSON.stringify(output)}`)
+	const msg = await bot.helpers.editOriginalInteractionResponse(interaction.token, output);
+	bot.logger.debug(`Message:\n${JSON.stringify(msg)}`);
+    }
+    return
+}

--- a/src/lib/usercomms/sourceSubmit.js
+++ b/src/lib/usercomms/sourceSubmit.js
@@ -1,0 +1,48 @@
+import ackInteraction from "../../util/ackInteraction.js";
+import {
+} from "../../../deps.js";
+import { usergameDB } from "./commandDB.js";
+
+export function sourceCommand(bot, interaction) {
+    const sourceData = interaction.data;
+    const sourceId = sourceData.customId;
+    const userId = sourceId.split('_')[1];
+    const commandComponent = sourceData.components[0].components[0]
+    const commandName = commandComponent.customId;
+    const commandSource = commandComponent.value;
+    bot.logger.debug(`Interaction Data: ${JSON.stringify(sourceData)}`);
+
+    if (sourceId.endsWith("create")) {
+	const success = usergameDB.createCommand(
+	    `${userId}`,
+	    commandName,
+	    commandSource
+	);
+	if (success) {
+	    ackInteraction(interaction, "message", {ephemeral: true}, {
+		content: `Created Command "${commandName}":\`\`\`${commandSource.slice(0,1500)}\`\`\``
+	    });
+	}else {
+	    ackInteraction(interaction, "message", {ephemeral: true}, {
+		content: `Failed to Create Command ${commandName}`
+	    });
+	}
+    }else if (sourceId.endsWith("update")) {
+	const success = usergameDB.updateCommand(
+	    `${userId}`,
+	    commandName,
+	    commandSource
+	);
+	if (success) {
+	    ackInteraction(interaction, "message", {ephemeral: true}, {
+		content: `Updated Command "${commandName}" to:\`\`\`${commandSource.slice(0,1500)}\`\`\``
+	    });
+	}else {
+	    ackInteraction(interaction, "message", {ephemeral: true}, {
+		content: `Failed to Create Command ${commandName}`
+	    });
+	}
+    }
+
+    return
+}

--- a/src/lib/usercomms/updateCommand.js
+++ b/src/lib/usercomms/updateCommand.js
@@ -1,0 +1,75 @@
+import ackInteraction from "../../util/ackInteraction.js";
+import {
+    MessageComponentTypes,
+    TextStyles,
+} from "../../../deps.js";
+import { usergameDB } from "./commandDB.js";
+
+export function updateCommand(bot, interaction) {
+    const createOptions = interaction.data.options.filter(
+	o => o.name == "update"
+    )[0].options;
+
+    const commandId = createOptions.filter(
+	o => o.name == "command"
+    )[0]["value"];
+
+    bot.logger.debug(`Updating command ${commandId}`);
+
+    // Check if command name exists, if it does, complain
+    // Otherwise present the modal
+
+    const exists = usergameDB.searchCommand({name: commandId})
+
+    if (exists.length == 0) {
+	ackInteraction(
+	    interaction,
+	    "message",
+	    {ephemeral: true},
+	    {
+		content: `Command with name ${commandId} does not exist!`
+	    }
+	);
+    }else {
+	const commandUserId = exists[0][1];
+	let userId;
+	if (interaction.member) {
+	    userId = `${interaction.member.id}`;
+	}else {
+	    userId = `${interaction.user.id}`;
+	}
+	if (userId == commandUserId) {
+	    ackInteraction(
+		interaction,
+		"modal",
+		{ephemeral: true},
+		{
+		    customId: `usergame_${userId}_src_update`,
+		    title: `${commandId}: Code Update`,
+		    components: [{
+			type: MessageComponentTypes.ActionRow,
+			components: [{
+			    type: MessageComponentTypes.InputText,
+			    customId: `${commandId}`,
+			    style: TextStyles.Paragraph,
+			    label: "Source Code",
+			    value: exists[0][6]
+			}]	
+		    }]
+		}
+	    );
+	}else {
+	    bot.logger.debug(`User ${userId} tried to modify ${commandUserId}'s command`);
+
+	    ackInteraction(
+		interaction,
+		"message",
+		{ephemeral: true},
+		{
+		    content: `You did not make ${commandId}`
+		}
+	    );
+	}
+    }
+    return
+}

--- a/src/lib/usercomms/usercomm_test.js
+++ b/src/lib/usercomms/usercomm_test.js
@@ -1,0 +1,111 @@
+import { assert } from "../../../deps.js";
+import { usergameDB } from "./commandDB.js";
+
+Deno.test("User Command Testing", async (t) => {
+    await t.step("Creating a Command", () => {
+	const success = usergameDB.createCommand(
+	    "TestUser",
+	    "printHello",
+	    `print("hello")`
+	);
+	assert(success);
+    });
+
+    await t.step("Searching for Command", () => {
+	const res = usergameDB.searchCommand(
+	    "TestUser",
+	    "printHello",
+	);
+	assert(res.length == 1);
+    });    
+    
+    await t.step("Updating a Command", () => {
+	const success = usergameDB.updateCommand(
+	    "TestUser",
+	    "printHello",
+	    `print("goodbye")`
+	);
+	assert(success);
+    });
+
+    await t.step("Create an existing Command", () => {
+	const success = usergameDB.createCommand(
+	    "TestUser",
+	    "printHello",
+	    `print("nihil")`
+	);
+	assert(!success);
+    });
+
+    await t.step("Updating a non-existent Command", () => {
+	const success = usergameDB.updateCommand(
+	    "TestUser",
+	    "noway",
+	    `print("goodbye")`
+	);
+	assert(!success);
+    });
+
+    await t.step("Run a Command", async () => {
+	const res = await usergameDB.runCommand(
+	    "printHello"
+	);
+	console.log(res);
+	assert(res.content == "goodbye");
+    });
+
+    await t.step("Create a second Command", () => {
+	const success = usergameDB.createCommand(
+	    "TestUser",
+	    "echo",
+	    `print(input())`
+	);
+	assert(success);
+    });
+
+    await t.step("Query all Commands", () => {
+	const res = usergameDB.searchCommand();
+	console.log(res)
+	assert(res.length == 2);
+    });
+
+    await t.step("Run Command With Input", async () => {
+	const res = await usergameDB.runCommand(
+	    "echo",
+	    "hello"
+	);
+	console.log(res);
+	assert(res.content == "hello");
+    });
+
+    await t.step("Run Command With Input That Doesn't Use It", async () => {
+	const res = await usergameDB.runCommand(
+	    "printHello",
+	    "hello"
+	);
+	console.log(res);
+	assert(res.content == "goodbye");
+    });
+    
+    await t.step("Delete a Command", () => {
+	usergameDB.deleteCommand(
+	    "TestUser",
+	    "printHello"
+	);
+	const res = usergameDB.searchCommand("TestUser", "printHello")
+	assert(res.length == 1);
+    });
+
+    await t.step("Create and run Command With Files", async () => {
+	usergameDB.createCommand(
+	    "TestUser",
+	    "file",
+	    `with open("/out/test.txt","w") as f:
+	      f.write("aaaa")`
+	);
+	const res = await usergameDB.runCommand("file");
+	console.log(res);
+	assert(res.file[0].blob.size == 4);
+    });
+
+});


### PR DESCRIPTION
To come: more than python, and allow commands to depend on each other for stringing together many commands

This is a combination of 125 commits:
Basic User-Command Infra Started

Restructure & Fix Import

I can Code

Need Better Testing for These Types of Errors:tm:

Master Command Organization

Basic Create Command "Interaction"

Import Ack Properly

Really Need to Implement Something

Where did that ] Come From

Wah

Basic Modal Response Format

Ignore Training Ham

Don't Double Option

Moar ?

Missing TextStyles Import

Debug

Moar Debug

Possible Tagging issue

Improper User Naming

Interaction Data

Logging

Think not Defer

Message ACK

Debug Creation

Unused Import

Grab Command Name Value

BigInt BadInt

No longer using bot

Basic Stuff, maybe working, maybe not

Add Sqlite To Dev (For checking and controlling sqlite DB)

Add Tests for Adding, and Updating DBs

Formatting Logging

Add Delete Command

Add Delete Test

Formatting

Add BubbleWrap

Fix Linting

Update Deno, Python, BQN, and Everything Else

Update Deno.run() -> Deno.Command()

Add BQN Test

Add Code Execution bb

Forgot to uncomment Logger

Change Search Format

Match Test to Search Format

Add Text Input Support to Commands

Update Discord Interaction End

Add TMPDIR ENV for Deno-Tests

Add CoreUtils for Timeout

Mount tmpfs

Add SELinux Opts for Bwrap in Podman

Fix Non-Default Import

Fix Logging in Command Creation and Submission

Fix BigInt Forever

Logging? Logging.

Get Component Data: Test

Add Continues for Lint

TODO Log Instead of Continue (Lint did not Catch)

Me no Thinky

Ensure Confirmation Message Isn't Too Long

Implement Source Update & Creation

Implement Update Command

Debug Log Creation

Reformat Modal

How did linting not catch this

Big Smrt

Do Imports

Make Messages Ephemeral

Debug Update Log

Ephemeral logs

I can Index

Fix Log

Better Indexing

Add Run and Delete Command

Test Input String

Use Real Input

Default Command Output Value

Real Output bb

Block Out Command Formatting

Clear Bubblewrap env (security)

Fix Lint

Use Appropriate Flag Value

I really Kinda Didn't Read or Think:tm:

Linting Did not Catch Flags

Send Follow up (For changing ephemerability of command)

Use Discordeno 18 Format for Followup

Need to Investigate Followup

Use Hidden Suboption Instead

Remove Unused Flags for Ephemeral

Fix Changes to formatOutput

Add Message Command for Running UserCommands

Pass User Message Through Modal

This is Why We Don't Copy Paste Our Own Code

Add Info Command

Fix Copied Code (Should Really make a function)

Declare const

Can't Use @s ot <t:>'s in Embeds

Add FUSE tmpfs

Add list command

No Options Yet (lint)

!= -> ==

Actually put List in MasterAction

Possibly Functional List

Remove Copied Msg from Logs

Debug Fields

" -> `

I can Think

Undef when no commands

Add fuse

Whoops, wrong command order

Add Attachments

fusermount -> fusermount3

Log Command Outputs

Mixed Documentation

Heckin Name Changes

Try Using Helper

Attach in Followup

Await Edit

U -> u

Debug Message

Stringify

Idk man, all of them

}

Conflicting Docs, Yeesh

Change max attachments to 50

10 is the limit